### PR TITLE
Add versioning system with release channels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Extract version metadata
+        id: meta
+        run: |
+          # Extract version from package.json
+          VERSION=$(grep '"version"' code/frontend/package.json | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Detect channel from git ref
+          if [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            CHANNEL="stable"
+          elif [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+-(rc|beta) ]]; then
+            CHANNEL="release"
+          else
+            CHANNEL="dev"
+          fi
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+
       - name: Build ${{ matrix.image }}
         env:
           DOCKER_BUILDKIT: '1'
@@ -35,6 +52,8 @@ jobs:
           docker build -f ${{ matrix.dockerfile }} \
             ${{ matrix.target && format('--target {0}', matrix.target) || '' }} \
             -t "${{ matrix.image }}:${{ inputs.image-tag }}" \
+            --build-arg VERSION=${{ steps.meta.outputs.version }} \
+            --build-arg CHANNEL=${{ steps.meta.outputs.channel }} \
             --build-arg COMMIT_HASH=${{ github.sha }} \
             --build-arg BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) .
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ kubectl port-forward -n kubarr svc/kubarr-frontend 8080:80
 - **[User Guide](./docs/user-guide.md)** - How to use Kubarr features effectively
 - **[Architecture](./docs/architecture.md)** - System architecture and design decisions
 - **[API Documentation](./docs/api.md)** - REST API reference for integrations
+- **[Versioning System](./docs/versioning.md)** - Version management, release channels, and release workflow
 - **[Contributing Guide](./CONTRIBUTING.md)** - How to contribute to Kubarr development
 - **[Security Policy](./code/backend/SECURITY.md)** - Security practices and vulnerability reporting
 - **[Developer Setup](./CLAUDE.md)** - Development environment setup and workflow

--- a/code/backend/src/application/config/mod.rs
+++ b/code/backend/src/application/config/mod.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub commit_hash: String,
     pub build_time: String,
     pub version: String,
+    pub channel: String,
 
     // Logging
     pub log_level: String,
@@ -42,6 +43,7 @@ impl Config {
             commit_hash: env::var("COMMIT_HASH").unwrap_or_else(|_| "unknown".to_string()),
             build_time: env::var("BUILD_TIME").unwrap_or_else(|_| "unknown".to_string()),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            channel: env::var("CHANNEL").unwrap_or_else(|_| "dev".to_string()),
 
             // Logging
             log_level: env::var("KUBARR_LOG_LEVEL").unwrap_or_else(|_| "info".to_string()),

--- a/code/backend/src/endpoints/mod.rs
+++ b/code/backend/src/endpoints/mod.rs
@@ -294,6 +294,7 @@ async fn health_check_detailed(State(state): State<AppState>) -> axum::Json<serd
 async fn get_version() -> axum::Json<serde_json::Value> {
     axum::Json(serde_json::json!({
         "version": CONFIG.version,
+        "channel": CONFIG.channel,
         "commit_hash": CONFIG.commit_hash,
         "build_time": CONFIG.build_time,
         "rust_version": "1.83",

--- a/code/frontend/src/components/VersionFooter.tsx
+++ b/code/frontend/src/components/VersionFooter.tsx
@@ -1,36 +1,75 @@
 import { useState, useEffect } from 'react';
 
 interface BackendVersion {
+  version: string;
+  channel: string;
   commit_hash: string;
   build_time: string;
 }
 
+type Channel = 'dev' | 'release' | 'stable';
+
 export function VersionFooter() {
   const [backendVersion, setBackendVersion] = useState<BackendVersion | null>(null);
 
+  const frontendVersion = __VERSION__;
+  const frontendChannel = __CHANNEL__ as Channel;
   const frontendCommit = __COMMIT_HASH__;
   const frontendBuildTime = __BUILD_TIME__;
+
+  // Channel badge colors
+  const getChannelColor = (channel: Channel) => {
+    switch (channel) {
+      case 'stable':
+        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+      case 'release':
+        return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200';
+      case 'dev':
+      default:
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+    }
+  };
 
   useEffect(() => {
     fetch('/api/system/version')
       .then(res => res.json())
       .then(data => setBackendVersion(data))
-      .catch(() => setBackendVersion({ commit_hash: 'error', build_time: '' }));
+      .catch(() => setBackendVersion({
+        version: 'error',
+        channel: 'dev',
+        commit_hash: 'error',
+        build_time: ''
+      }));
   }, []);
 
   return (
     <footer className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-4 py-2 text-xs text-gray-500">
-      <div className="flex justify-center gap-6">
-        <span>
-          Frontend: <code className="text-gray-600 dark:text-gray-400">{frontendCommit}</code>
-          <span className="text-gray-400 dark:text-gray-600 ml-1">({new Date(frontendBuildTime).toLocaleString()})</span>
+      <div className="flex justify-center items-center gap-6">
+        <span className="flex items-center gap-2">
+          <span className={`px-2 py-0.5 rounded text-xs font-medium ${getChannelColor(frontendChannel)}`}>
+            {frontendChannel}
+          </span>
+          <span>v{frontendVersion}</span>
+          <code className="text-gray-600 dark:text-gray-400">{frontendCommit.substring(0, 7)}</code>
+          <span className="text-gray-400 dark:text-gray-600">({new Date(frontendBuildTime).toLocaleDateString()})</span>
         </span>
-        <span>|</span>
-        <span>
-          Backend: <code className="text-gray-600 dark:text-gray-400">{backendVersion?.commit_hash || 'loading...'}</code>
-          {backendVersion?.build_time && (
-            <span className="text-gray-400 dark:text-gray-600 ml-1">({new Date(backendVersion.build_time).toLocaleString()})</span>
+
+        <span className="text-gray-300 dark:text-gray-700">|</span>
+
+        <span className="flex items-center gap-2">
+          {backendVersion && (
+            <>
+              <span className={`px-2 py-0.5 rounded text-xs font-medium ${getChannelColor(backendVersion.channel as Channel)}`}>
+                {backendVersion.channel}
+              </span>
+              <span>v{backendVersion.version}</span>
+              <code className="text-gray-600 dark:text-gray-400">{backendVersion.commit_hash.substring(0, 7)}</code>
+              {backendVersion.build_time && (
+                <span className="text-gray-400 dark:text-gray-600">({new Date(backendVersion.build_time).toLocaleDateString()})</span>
+              )}
+            </>
           )}
+          {!backendVersion && <span>Loading backend version...</span>}
         </span>
       </div>
     </footer>

--- a/code/frontend/src/vite-env.d.ts
+++ b/code/frontend/src/vite-env.d.ts
@@ -1,7 +1,9 @@
 /// <reference types="vite/client" />
 
+declare const __VERSION__: string;
 declare const __COMMIT_HASH__: string;
 declare const __BUILD_TIME__: string;
+declare const __CHANNEL__: string;
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string

--- a/code/frontend/vite.config.ts
+++ b/code/frontend/vite.config.ts
@@ -2,6 +2,23 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+// Get version from environment or package.json
+const getVersion = () => {
+  // Check environment variable first (set in Docker build)
+  if (process.env.VITE_VERSION && process.env.VITE_VERSION !== '0.0.0') {
+    return process.env.VITE_VERSION
+  }
+  // Fall back to package.json for local development
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8'))
+    return pkg.version
+  } catch {
+    return '0.0.0'
+  }
+}
 
 // Get git commit hash at build time
 const getGitHash = () => {
@@ -25,13 +42,20 @@ const getBuildTime = () => {
   return new Date().toISOString()
 }
 
+// Get release channel (dev, release, stable)
+const getChannel = () => {
+  return process.env.VITE_CHANNEL || 'dev'
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [tailwindcss(), react()],
   base: '/',
   define: {
+    __VERSION__: JSON.stringify(getVersion()),
     __COMMIT_HASH__: JSON.stringify(getGitHash()),
     __BUILD_TIME__: JSON.stringify(getBuildTime()),
+    __CHANNEL__: JSON.stringify(getChannel()),
   },
   server: {
     port: 5173,

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -79,6 +79,7 @@ FROM alpine:3.23
 # Build args for environment
 ARG COMMIT_HASH=unknown
 ARG BUILD_TIME=unknown
+ARG CHANNEL=dev
 
 # Install CA certificates for HTTPS
 RUN apk add --no-cache ca-certificates tzdata
@@ -97,6 +98,7 @@ RUN mkdir -p /app/charts
 # Set environment variables
 ENV COMMIT_HASH=${COMMIT_HASH}
 ENV BUILD_TIME=${BUILD_TIME}
+ENV CHANNEL=${CHANNEL}
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 # Expose API port

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -13,10 +13,14 @@ RUN npm ci
 COPY code/frontend/ ./
 
 # Build args for version info
+ARG VERSION=0.0.0
+ARG CHANNEL=dev
 ARG COMMIT_HASH=unknown
 ARG BUILD_TIME=unknown
 
 # Set build-time environment variables for Vite
+ENV VITE_VERSION=${VERSION}
+ENV VITE_CHANNEL=${CHANNEL}
 ENV VITE_COMMIT_HASH=${COMMIT_HASH}
 ENV VITE_BUILD_TIME=${BUILD_TIME}
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,398 @@
+# Versioning System
+
+Kubarr uses **Semantic Versioning** (SemVer) with a release channel system to distinguish between development, release candidate, and production builds.
+
+## Version Format
+
+Versions follow the **MAJOR.MINOR.PATCH** format (e.g., `1.2.3`):
+
+- **MAJOR**: Incremented for incompatible API changes or major features
+- **MINOR**: Incremented for backwards-compatible new features
+- **PATCH**: Incremented for backwards-compatible bug fixes
+
+## Release Channels
+
+Kubarr has three release channels:
+
+| Channel | Description | Tag Pattern | Badge Color | Use Case |
+|---------|-------------|-------------|-------------|----------|
+| **dev** | Development builds | No tag or unmatched tag | Blue | Active development, latest features |
+| **release** | Release candidates | `v*.*.*-rc.*`, `v*.*.*-beta.*` | Yellow | Pre-release testing, beta features |
+| **stable** | Production releases | `v*.*.*` | Green | Production deployments |
+
+### Channel Detection
+
+The build system automatically detects the channel based on git tags:
+
+```bash
+# Stable release (channel: stable)
+git tag v1.2.3
+
+# Release candidate (channel: release)
+git tag v1.2.3-rc.1
+git tag v1.2.3-beta.1
+
+# Development build (channel: dev)
+# No tag or any commit not matching above patterns
+```
+
+## Version Bumping Workflow
+
+### Using the Script
+
+The `scripts/version-bump.sh` script automates version updates across the entire codebase:
+
+```bash
+# Bump patch version (0.1.0 -> 0.1.1)
+./scripts/version-bump.sh patch --tag
+
+# Bump minor version (0.1.0 -> 0.2.0)
+./scripts/version-bump.sh minor --tag
+
+# Bump major version (0.1.0 -> 1.0.0)
+./scripts/version-bump.sh major --tag
+
+# Create a release candidate
+./scripts/version-bump.sh minor --channel release --tag
+
+# Dry run (preview changes without modifying files)
+./scripts/version-bump.sh patch --dry-run
+```
+
+#### Script Options
+
+- `<major|minor|patch>`: Version component to bump (required)
+- `--channel <dev|release|stable>`: Release channel (default: stable)
+- `--tag`: Automatically create a git tag after bumping
+- `--dry-run`: Show what would change without modifying files
+
+### What Gets Updated
+
+The version-bump script updates:
+
+1. **code/frontend/package.json**: `"version"` field
+2. **code/backend/Cargo.toml**: `version` field
+3. **code/backend/Cargo.lock**: via `cargo check`
+
+### Manual Version Bump
+
+If you prefer to bump versions manually:
+
+1. Update `code/frontend/package.json` version
+2. Update `code/backend/Cargo.toml` version
+3. Run `cd code/backend && cargo check` to update Cargo.lock
+4. Commit the changes
+5. Create a git tag: `git tag -a v1.2.3 -m "Release 1.2.3"`
+
+## Release Workflow
+
+### Development Releases (dev channel)
+
+Development builds are created automatically from any untagged commit:
+
+```bash
+# Make changes
+git add .
+git commit -m "Add new feature"
+git push
+
+# Deploy (channel will be "dev")
+./scripts/deploy.sh
+```
+
+### Release Candidates (release channel)
+
+Create release candidates for testing before stable releases:
+
+```bash
+# Bump version and create RC tag
+./scripts/version-bump.sh minor --channel release --tag
+
+# Push changes and tag
+git push
+git push origin v0.2.0-rc.1
+
+# Deploy (channel will be "release")
+./scripts/deploy.sh
+```
+
+### Stable Releases (stable channel)
+
+Create stable releases for production deployments:
+
+```bash
+# Bump version and create stable tag
+./scripts/version-bump.sh patch --tag
+
+# Push changes and tag
+git push
+git push origin v0.1.1
+
+# Deploy (channel will be "stable")
+./scripts/deploy.sh
+```
+
+### Converting RC to Stable
+
+If you have a release candidate that's ready for production:
+
+```bash
+# Create a stable tag at the same commit as the RC
+git tag -a v0.2.0 -m "Release 0.2.0" v0.2.0-rc.1
+git push origin v0.2.0
+```
+
+## Branch Protection Rules
+
+To enforce the versioning workflow and prevent accidental releases, configure the following branch protection rules:
+
+### Main Branch Protection
+
+Configure these rules for the `main` branch in your GitHub repository:
+
+1. **Settings → Branches → Add rule**
+2. **Branch name pattern**: `main`
+3. **Protect matching branches**:
+   - ✅ Require a pull request before merging
+     - ✅ Require approvals (at least 1)
+     - ✅ Dismiss stale pull request approvals when new commits are pushed
+   - ✅ Require status checks to pass before merging
+     - ✅ Require branches to be up to date before merging
+     - Required checks:
+       - `docker / docker (kubarr-backend-test)` - Backend tests
+       - `docker / docker (kubarr-frontend-test)` - Frontend tests
+       - `docs` - Documentation build
+   - ✅ Require conversation resolution before merging
+   - ✅ Do not allow bypassing the above settings (even for admins)
+
+### Tag Protection Rules
+
+Protect version tags to prevent accidental modifications or deletions:
+
+1. **Settings → Tags → Add rule**
+2. **Tag name pattern**: `v*`
+3. **Protection rules**:
+   - ✅ Protect matching tags
+   - Only allow repository admins to delete protected tags
+
+### Recommended Workflow with Protection
+
+With branch protection enabled:
+
+```bash
+# 1. Create a feature branch
+git checkout -b feature/my-feature
+
+# 2. Make changes and commit
+git add .
+git commit -m "Add my feature"
+
+# 3. Push branch
+git push origin feature/my-feature
+
+# 4. Create Pull Request on GitHub
+# - Tests will run automatically
+# - Request review from team member
+# - Wait for approval
+
+# 5. Merge PR (via GitHub UI)
+# - Squash and merge or merge commit
+# - Delete feature branch after merge
+
+# 6. Create release (on main branch)
+git checkout main
+git pull
+./scripts/version-bump.sh patch --tag
+git push
+git push origin v0.1.1
+```
+
+### Enforcing Version Tags
+
+To require that all deployments to production use tagged releases, you can:
+
+1. **GitHub Actions**: Add a condition to deployment workflows
+   ```yaml
+   if: startsWith(github.ref, 'refs/tags/v')
+   ```
+
+2. **Kubernetes**: Use image tags based on git tags instead of `:latest`
+   ```yaml
+   image: kubarr-backend:v0.1.1
+   ```
+
+3. **Monitoring**: Set up alerts for deployments with `channel: dev` in production
+
+## Version Display
+
+Version information is displayed in multiple locations:
+
+### UI Footer
+
+The frontend footer shows:
+- Channel badge (color-coded: blue=dev, yellow=release, green=stable)
+- Version number (e.g., `v0.1.0`)
+- Short commit hash (7 characters)
+- Build date
+
+Example: `[dev] v0.1.0 a1b2c3d (2026-02-16) | [dev] v0.1.0 a1b2c3d (2026-02-16)`
+
+### API Endpoint
+
+Version information is available via REST API:
+
+```bash
+curl http://localhost:8080/api/system/version | jq
+```
+
+Response:
+```json
+{
+  "version": "0.1.0",
+  "channel": "dev",
+  "commit_hash": "a1b2c3d",
+  "build_time": "2026-02-16T10:30:00Z",
+  "rust_version": "1.83",
+  "backend": "rust"
+}
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+The build workflow automatically extracts version metadata:
+
+```yaml
+- name: Extract version metadata
+  id: meta
+  run: |
+    VERSION=$(grep '"version"' code/frontend/package.json | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
+    echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    if [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      CHANNEL="stable"
+    elif [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+-(rc|beta) ]]; then
+      CHANNEL="release"
+    else
+      CHANNEL="dev"
+    fi
+    echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+
+- name: Build
+  run: |
+    docker build \
+      --build-arg VERSION=${{ steps.meta.outputs.version }} \
+      --build-arg CHANNEL=${{ steps.meta.outputs.channel }} \
+      ...
+```
+
+### Local Builds
+
+The deploy script automatically detects the channel:
+
+```bash
+./scripts/deploy.sh
+```
+
+The script will:
+1. Extract version from `code/frontend/package.json`
+2. Check for git tags on current commit
+3. Determine channel based on tag pattern
+4. Pass version and channel to Docker builds
+
+## Docker Build Arguments
+
+Both Dockerfiles accept version metadata as build arguments:
+
+**Backend (docker/Dockerfile.backend):**
+```dockerfile
+ARG COMMIT_HASH=unknown
+ARG BUILD_TIME=unknown
+ARG CHANNEL=dev
+
+ENV COMMIT_HASH=${COMMIT_HASH}
+ENV BUILD_TIME=${BUILD_TIME}
+ENV CHANNEL=${CHANNEL}
+```
+
+**Frontend (docker/Dockerfile.frontend):**
+```dockerfile
+ARG VERSION=0.0.0
+ARG CHANNEL=dev
+ARG COMMIT_HASH=unknown
+ARG BUILD_TIME=unknown
+
+ENV VITE_VERSION=${VERSION}
+ENV VITE_CHANNEL=${CHANNEL}
+ENV VITE_COMMIT_HASH=${COMMIT_HASH}
+ENV VITE_BUILD_TIME=${BUILD_TIME}
+```
+
+## Troubleshooting
+
+### Version not updating in UI
+
+1. Verify build args are passed to Docker:
+   ```bash
+   docker build --build-arg VERSION=0.1.0 --build-arg CHANNEL=dev ...
+   ```
+
+2. Check environment variables in container:
+   ```bash
+   kubectl exec -n kubarr deployment/kubarr-backend -- env | grep -E 'VERSION|CHANNEL|COMMIT'
+   ```
+
+3. Verify API endpoint returns correct version:
+   ```bash
+   curl http://localhost:8080/api/system/version
+   ```
+
+### Channel not detected correctly
+
+1. Check current git tag:
+   ```bash
+   git describe --exact-match --tags
+   ```
+
+2. Verify tag pattern matches expected format:
+   - Stable: `v1.2.3` (exactly)
+   - Release: `v1.2.3-rc.1` or `v1.2.3-beta.1`
+
+3. Re-run deploy script to pick up tag:
+   ```bash
+   ./scripts/deploy.sh
+   ```
+
+### Version mismatch between frontend and backend
+
+Both should use the same version from `package.json`. If they differ:
+
+1. Run version-bump script to sync:
+   ```bash
+   ./scripts/version-bump.sh patch
+   ```
+
+2. Or manually update both files:
+   - `code/frontend/package.json`
+   - `code/backend/Cargo.toml`
+
+## Best Practices
+
+1. **Always tag releases**: Use `./scripts/version-bump.sh` with `--tag` to ensure consistent versioning
+
+2. **Use release candidates**: Test with `--channel release` before creating stable tags
+
+3. **Keep versions synchronized**: Frontend and backend versions should always match
+
+4. **Document breaking changes**: When bumping major version, document what changed in the commit message or changelog
+
+5. **Automate deployments**: Use GitHub Actions to deploy tagged releases automatically
+
+6. **Monitor channels**: Set up alerts for unexpected channels in production (e.g., `dev` channel in prod should trigger an alert)
+
+7. **Clean up old tags**: Remove RC/beta tags after promoting to stable:
+   ```bash
+   git tag -d v1.2.3-rc.1
+   git push origin :refs/tags/v1.2.3-rc.1
+   ```

--- a/scripts/version-bump.sh
+++ b/scripts/version-bump.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+    echo "Usage: $0 <major|minor|patch> [OPTIONS]"
+    echo ""
+    echo "Bump version across backend and frontend."
+    echo ""
+    echo "Arguments:"
+    echo "  major       Bump major version (e.g., 1.2.3 -> 2.0.0)"
+    echo "  minor       Bump minor version (e.g., 1.2.3 -> 1.3.0)"
+    echo "  patch       Bump patch version (e.g., 1.2.3 -> 1.2.4)"
+    echo ""
+    echo "Options:"
+    echo "  --channel <dev|release|stable>  Release channel (default: stable)"
+    echo "  --tag                            Create git tag after bumping"
+    echo "  --dry-run                        Show what would change without modifying files"
+    echo "  --help                           Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0 patch --tag                    # 0.1.0 -> 0.1.1, create v0.1.1 tag"
+    echo "  $0 minor --channel release --tag  # 0.1.0 -> 0.2.0-rc.1, create tag"
+    echo "  $0 major --dry-run                # Show what would happen for major bump"
+}
+
+# Parse arguments
+BUMP_TYPE=""
+CHANNEL="stable"
+CREATE_TAG=false
+DRY_RUN=false
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        major|minor|patch)
+            if [ -n "$BUMP_TYPE" ]; then
+                echo "Error: Bump type already specified"
+                exit 1
+            fi
+            BUMP_TYPE="$1"
+            shift
+            ;;
+        --channel)
+            CHANNEL="$2"
+            if [[ ! "$CHANNEL" =~ ^(dev|release|stable)$ ]]; then
+                echo "Error: Channel must be dev, release, or stable"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --tag)
+            CREATE_TAG=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$BUMP_TYPE" ]; then
+    echo "Error: Bump type (major, minor, or patch) is required"
+    usage
+    exit 1
+fi
+
+cd "$PROJECT_ROOT"
+
+# Get current version from package.json
+CURRENT_VERSION=$(grep '"version"' code/frontend/package.json | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
+if [ -z "$CURRENT_VERSION" ]; then
+    echo "Error: Could not read current version from package.json"
+    exit 1
+fi
+
+echo "Current version: $CURRENT_VERSION"
+
+# Parse version components
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+# Strip any pre-release suffix from patch (e.g., "3-rc.1" -> "3")
+PATCH=$(echo "$PATCH" | sed 's/-.*//')
+
+# Calculate new version
+case "$BUMP_TYPE" in
+    major)
+        NEW_MAJOR=$((MAJOR + 1))
+        NEW_MINOR=0
+        NEW_PATCH=0
+        ;;
+    minor)
+        NEW_MAJOR=$MAJOR
+        NEW_MINOR=$((MINOR + 1))
+        NEW_PATCH=0
+        ;;
+    patch)
+        NEW_MAJOR=$MAJOR
+        NEW_MINOR=$MINOR
+        NEW_PATCH=$((PATCH + 1))
+        ;;
+esac
+
+NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
+
+# Add channel suffix for release channel
+TAG_VERSION="$NEW_VERSION"
+if [ "$CHANNEL" = "release" ]; then
+    TAG_VERSION="$NEW_VERSION-rc.1"
+fi
+
+echo "New version: $NEW_VERSION"
+echo "Channel: $CHANNEL"
+if [ "$CREATE_TAG" = true ]; then
+    echo "Git tag: v$TAG_VERSION"
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    echo ""
+    echo "=== DRY RUN - No files will be modified ==="
+    echo ""
+    echo "Would update:"
+    echo "  - code/frontend/package.json: $CURRENT_VERSION -> $NEW_VERSION"
+    echo "  - code/backend/Cargo.toml: $CURRENT_VERSION -> $NEW_VERSION"
+    echo "  - code/backend/Cargo.lock (via cargo check)"
+    if [ "$CREATE_TAG" = true ]; then
+        echo "  - Create git tag: v$TAG_VERSION"
+    fi
+    exit 0
+fi
+
+# Update package.json
+echo ""
+echo "Updating code/frontend/package.json..."
+sed -i "s/\"version\": \"$CURRENT_VERSION\"/\"version\": \"$NEW_VERSION\"/" code/frontend/package.json
+
+# Update Cargo.toml
+echo "Updating code/backend/Cargo.toml..."
+sed -i "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" code/backend/Cargo.toml
+
+# Update Cargo.lock
+echo "Updating code/backend/Cargo.lock..."
+cd code/backend
+cargo check --quiet 2>/dev/null || cargo check
+cd "$PROJECT_ROOT"
+
+echo ""
+echo "=== Version Bump Complete ==="
+echo ""
+echo "Updated files:"
+echo "  - code/frontend/package.json"
+echo "  - code/backend/Cargo.toml"
+echo "  - code/backend/Cargo.lock"
+echo ""
+
+if [ "$CREATE_TAG" = true ]; then
+    echo "Creating git tag v$TAG_VERSION..."
+    git tag -a "v$TAG_VERSION" -m "Release $TAG_VERSION"
+    echo ""
+    echo "Git tag created: v$TAG_VERSION"
+    echo ""
+    echo "To push changes and tag:"
+    echo "  git add code/frontend/package.json code/backend/Cargo.toml code/backend/Cargo.lock"
+    echo "  git commit -m \"Bump version to $NEW_VERSION\""
+    echo "  git push"
+    echo "  git push origin v$TAG_VERSION"
+else
+    echo "To commit these changes:"
+    echo "  git add code/frontend/package.json code/backend/Cargo.toml code/backend/Cargo.lock"
+    echo "  git commit -m \"Bump version to $NEW_VERSION\""
+    echo ""
+    echo "To create a tag later:"
+    echo "  git tag -a v$TAG_VERSION -m \"Release $TAG_VERSION\""
+    echo "  git push origin v$TAG_VERSION"
+fi


### PR DESCRIPTION
## Summary

Implements a comprehensive versioning system with semantic versioning and release channels to clearly distinguish between development, release candidate, and production builds.

## Changes

### Backend
- ✅ Add `channel` field to Config struct for runtime channel detection
- ✅ Update `/api/system/version` endpoint to return channel information
- ✅ Add `CHANNEL` build arg to Dockerfile

### Frontend
- ✅ Add TypeScript declarations for `__VERSION__` and `__CHANNEL__` globals
- ✅ Enhance VersionFooter component with color-coded channel badges (🟢 stable, 🟡 release, 🔵 dev)
- ✅ Display version numbers alongside commit hashes
- ✅ Add `VERSION` and `CHANNEL` build args to Dockerfile

### Build Automation
- ✅ Update `scripts/deploy.sh` to extract version from package.json and detect channel from git tags
- ✅ Create `scripts/version-bump.sh` for automated version management across frontend and backend
- ✅ Update GitHub Actions workflow to pass version metadata as build args

### Documentation
- ✅ Add comprehensive versioning guide (`docs/versioning.md`) with release workflow
- ✅ Document branch protection rules to enforce release process
- ✅ Update README with link to versioning documentation

## Release Channels

The system automatically detects release channels based on git tags:

| Channel | Tag Pattern | Badge | Use Case |
|---------|-------------|-------|----------|
| **stable** | `v*.*.*` | 🟢 Green | Production releases |
| **release** | `v*.*.*-rc.*` or `v*.*.*-beta.*` | 🟡 Yellow | Release candidates |
| **dev** | No tag | 🔵 Blue | Development builds |

## Version Bump Examples

```bash
# Patch release (0.1.0 -> 0.1.1)
./scripts/version-bump.sh patch --tag

# Minor release (0.1.0 -> 0.2.0)
./scripts/version-bump.sh minor --tag

# Release candidate (0.1.0 -> 0.2.0-rc.1)
./scripts/version-bump.sh minor --channel release --tag

# Dry run to preview changes
./scripts/version-bump.sh patch --dry-run
```

## Testing

- ✅ Frontend builds successfully with new TypeScript declarations
- ✅ Version-bump script tested with dry-run mode
- ✅ Deploy script correctly extracts version and detects channel

## Next Steps

After merging this PR:
1. Set up branch protection rules as documented in `docs/versioning.md`
2. Create initial version tag: `git tag -a v0.1.0 -m "Initial release v0.1.0"`
3. Deploy and verify version display in UI footer

## Breaking Changes

None. This is a purely additive feature that enhances build metadata tracking.