### PR TITLE
Add versioning to documentation website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Extract version metadata
+        id: meta
+        run: |
+          # Extract version from package.json
+          VERSION=$(grep '"version"' code/frontend/package.json | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Detect channel from git ref
+          if [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            CHANNEL="stable"
+          elif [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+-(rc|beta) ]]; then
+            CHANNEL="release"
+          else
+            CHANNEL="dev"
+          fi
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
       - run: pip install mkdocs-material
-      - run: mkdocs build --strict -f docs/mkdocs.yml
+
+      - name: Build documentation
+        env:
+          KUBARR_VERSION: ${{ steps.meta.outputs.version }}
+          KUBARR_CHANNEL: ${{ steps.meta.outputs.channel }}
+          KUBARR_COMMIT: ${{ github.sha }}
+        run: mkdocs build --strict -f docs/mkdocs.yml

--- a/docs/hooks/version_info.py
+++ b/docs/hooks/version_info.py
@@ -1,0 +1,116 @@
+"""
+MkDocs hook to inject version information into the documentation.
+
+This hook extracts version information from:
+1. Environment variable KUBARR_VERSION (if set)
+2. Git tags (latest tag matching v*.*.*)
+3. Fallback to "dev"
+
+The version info is added to:
+- Site metadata (extra.version_info)
+- Copyright footer
+- Page headers
+"""
+
+import os
+import subprocess
+import re
+from datetime import datetime, timezone
+
+
+def get_version_info():
+    """Extract version information from environment or git."""
+    version = os.environ.get('KUBARR_VERSION', '')
+    channel = os.environ.get('KUBARR_CHANNEL', 'dev')
+
+    if not version:
+        # Try to get version from git tags
+        try:
+            # Get the latest tag
+            result = subprocess.run(
+                ['git', 'describe', '--tags', '--abbrev=0'],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+            if result.returncode == 0:
+                tag = result.stdout.strip()
+                # Extract version from tag (e.g., v1.2.3 -> 1.2.3)
+                version_match = re.match(r'v?(\d+\.\d+\.\d+)', tag)
+                if version_match:
+                    version = version_match.group(1)
+
+                    # Determine channel from tag
+                    if re.match(r'v?\d+\.\d+\.\d+$', tag):
+                        channel = 'stable'
+                    elif re.match(r'v?\d+\.\d+\.\d+-(rc|beta)', tag):
+                        channel = 'release'
+                    else:
+                        channel = 'dev'
+        except Exception:
+            pass
+
+    # Get commit hash
+    commit_hash = os.environ.get('KUBARR_COMMIT', '')
+    if not commit_hash:
+        try:
+            result = subprocess.run(
+                ['git', 'rev-parse', '--short', 'HEAD'],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+            if result.returncode == 0:
+                commit_hash = result.stdout.strip()
+        except Exception:
+            commit_hash = 'unknown'
+
+    # Fallback values
+    if not version:
+        version = '0.0.0'
+
+    return {
+        'version': version,
+        'channel': channel,
+        'commit': commit_hash,
+        'build_date': datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    }
+
+
+def on_config(config, **kwargs):
+    """Called when MkDocs config is loaded."""
+    # Get version info
+    version_info = get_version_info()
+
+    # Add to extra config for templates
+    if 'extra' not in config:
+        config['extra'] = {}
+    config['extra']['version_info'] = version_info
+
+    # Update copyright with version info
+    channel_emoji = {
+        'stable': '🟢',
+        'release': '🟡',
+        'dev': '🔵'
+    }.get(version_info['channel'], '🔵')
+
+    version_str = f"{channel_emoji} v{version_info['version']} ({version_info['channel']}) • {version_info['commit']}"
+
+    if 'copyright' in config and config['copyright']:
+        config['copyright'] += f" • {version_str}"
+    else:
+        config['copyright'] = f"© 2026 Kubarr Contributors • {version_str}"
+
+    return config
+
+
+def on_page_markdown(markdown, page, config, files):
+    """Called when page markdown is loaded, before rendering."""
+    # Replace version placeholders in markdown
+    version_info = config.get('extra', {}).get('version_info', {})
+
+    markdown = markdown.replace('{{VERSION}}', version_info.get('version', '0.0.0'))
+    markdown = markdown.replace('{{CHANNEL}}', version_info.get('channel', 'dev'))
+    markdown = markdown.replace('{{COMMIT}}', version_info.get('commit', 'unknown'))
+
+    return markdown

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 **Smooth sailing for self-hosted media on Kubernetes.**
 
+![Version](https://img.shields.io/badge/version-{{VERSION}}-blue?style=flat-square)
+![Release](https://img.shields.io/badge/channel-{{CHANNEL}}-green?style=flat-square)
+![Build](https://img.shields.io/badge/commit-{{COMMIT}}-lightgrey?style=flat-square)
+
 ---
 
 ## What is Kubarr?
@@ -44,3 +48,15 @@ Kubarr comes with a curated catalog of popular homelab apps. Deploy them individ
 ## Next Steps
 
 - **[Quick Start](quick-start.md)** — Get running in 15 minutes
+- **[Versioning System](versioning.md)** — Learn about releases and version management
+
+---
+
+!!! info "Documentation Version"
+    You are viewing documentation for **Kubarr v{{VERSION}}** ({{CHANNEL}} channel).
+
+    - **Version**: {{VERSION}}
+    - **Release Channel**: {{CHANNEL}}
+    - **Commit**: {{COMMIT}}
+
+    See the [Versioning Guide](versioning.md) for release information and how to upgrade.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -8,6 +8,13 @@ repo_url: https://github.com/bmartensNL/Kubarr
 repo_name: bmartensNL/Kubarr
 edit_uri: edit/main/docs/
 
+# Version info (displayed in footer and used by plugins)
+# This can be overridden during build with: mkdocs build -e KUBARR_VERSION=1.0.0
+extra:
+  version:
+    provider: mike
+    default: stable
+
 theme:
   name: material
   palette:
@@ -40,6 +47,7 @@ nav:
   - Home: index.md
   - Quick Start: quick-start.md
   - Docker: docker.md
+  - Versioning: versioning.md
 
 markdown_extensions:
   - admonition
@@ -67,3 +75,6 @@ extra_css:
 
 plugins:
   - search
+
+hooks:
+  - hooks/version_info.py


### PR DESCRIPTION
## Summary

Adds comprehensive version display to the MkDocs documentation website, matching the versioning system in the application UI.

## Changes

### Documentation Homepage
- ✅ Added version badges at the top (version, channel, commit)
- ✅ Added version info callout box with release details
- ✅ Added link to Versioning guide in navigation

### Site-Wide Footer
- ✅ Dynamic footer showing: `© 2026 Kubarr Contributors • 🟢 v0.1.0 (stable) • 4662023`
- ✅ Color-coded channel indicators (🟢 stable, 🟡 release, 🔵 dev)

### Build Integration
- ✅ Created MkDocs hook (`docs/hooks/version_info.py`) to inject version info
- ✅ Updated GitHub Actions workflow to pass version metadata during docs build
- ✅ Hook extracts version from environment variables or git tags

### Navigation
- ✅ Added `versioning.md` to docs navigation menu

## How It Works

**Version Detection:**
1. Reads from environment variables (`KUBARR_VERSION`, `KUBARR_CHANNEL`, `KUBARR_COMMIT`)
2. Falls back to git tags if env vars not set
3. Defaults to `dev` channel if neither available

**Channel Detection:**
- `stable`: Tags matching `v*.*.*` (e.g., v1.2.3)
- `release`: Tags matching `v*.*.*-rc.*` or `v*.*.*-beta.*`
- `dev`: No tag or unmatched pattern

**Placeholders:**
- `{{VERSION}}` → Current version (e.g., 0.1.0)
- `{{CHANNEL}}` → Release channel (stable/release/dev)
- `{{COMMIT}}` → Short commit hash (e.g., 4662023)

## Preview

**Homepage:**
```
# Kubarr
[v0.1.0] [stable] [4662023] ← Badges

...content...

ℹ️ Documentation Version
You are viewing documentation for **Kubarr v0.1.0** (stable channel).
• Version: 0.1.0
• Release Channel: stable
• Commit: 4662023
```

**Footer (every page):**
```
© 2026 Kubarr Contributors • 🟢 v0.1.0 (stable) • 4662023
```

## Testing

Tested locally with:
```bash
export KUBARR_VERSION="0.1.0"
export KUBARR_CHANNEL="stable"
export KUBARR_COMMIT="4662023"
mkdocs build --strict -f docs/mkdocs.yml
```

Verified:
- ✅ Version badges display correctly
- ✅ Placeholders are replaced with actual values
- ✅ Footer shows version info on all pages
- ✅ Navigation includes versioning guide
- ✅ No build warnings or errors

## Related

- Builds on #22 (versioning system for application)
- Complements frontend VersionFooter component
- Matches version display patterns in application UI

## Breaking Changes

None. This is purely additive.