### PR TITLE
feat: one-line installation and Claude Action write permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Add one-line installation script with k3s bundling
- Fix Claude Code GitHub Action permissions (was read-only, now has write access to create branches and PRs)

## Changes
- `install.sh`: One-command install via k3s + Helm OCI chart
- `.github/workflows/claude.yml`: Grant `contents: write`, `pull-requests: write`, `issues: write` so the action can create PRs autonomously